### PR TITLE
Fix WEBM streaming causing errors due to duration

### DIFF
--- a/workshop/lua/mediaplayer/utils.lua
+++ b/workshop/lua/mediaplayer/utils.lua
@@ -306,7 +306,14 @@ if CLIENT then
 				end
 
 				if msg:StartWith("DURATION:") then
-					local duration = math.ceil(tonumber(string.sub(msg, 10)))
+					local str_duration = string.sub(msg, 10)
+					
+					local duration
+					if str_duration == "Infinity" then // Edgecase from fragmented webm
+						duration = math.huge
+					else
+						duration = math.ceil(tonumber(str_duration))
+					end
 
 					callback(true, duration)
 					panel:Remove()


### PR DESCRIPTION
This PR was created in response to an issue with WEBM streaming.
The error is due to `DURATION:` being provided with a string value `Infinity` rather than a fixed value.
Error can be replicated by simply streaming a WEBM in fragments to clients.