### PR TITLE
Remove redundant volume loop for media players

### DIFF
--- a/workshop/lua/mediaplayer/cl_init.lua
+++ b/workshop/lua/mediaplayer/cl_init.lua
@@ -27,16 +27,6 @@ function MediaPlayer.Volume( volume )
 		-- Set volume convar
 		RunConsoleCommand( "mediaplayer_volume", volume )
 
-		-- Apply volume to all media players
-		for _, mp in pairs( MediaPlayer.List ) do
-			if mp:IsPlaying() then
-				local media = mp:CurrentMedia()
-				if media then
-					media:Volume( volume )
-				end
-			end
-		end
-
 		hook.Run( MP.EVENTS.VOLUME_CHANGED, volume, cur )
 
 		cur = volume


### PR DESCRIPTION
Volume is already updated every tick based on the mediaplayer_volume convar. For players with 3d audio enabled, this loop causes a "blip" in volume before the next Think cycle, even when the player is out of proximity.